### PR TITLE
Fix: Prevent redundant model switch logging

### DIFF
--- a/aiAPIClient.js
+++ b/aiAPIClient.js
@@ -161,10 +161,13 @@ class AIAPIClient {
 
         // Switch to appropriate model based on role level
         if (role) {
+            const previousModel = this.model;
             try {
                 const level = SystemMessages.getLevel(role);
                 this._switchToModelLevel(level);
-                this.logger.info(`🤖 Switched to ${level} model (${this.model}) for role '${role}'`);
+                if (this.model !== previousModel) {
+                    this.logger.info(`🤖 Switched to ${level} model (${this.model}) for role '${role}'`);
+                }
             } catch (error) {
                 this.logger.warn(`Could not determine model level for role '${role}': ${error.message}`);
             }


### PR DESCRIPTION
The message "Switched to <level> model..." was being logged every time setSystemMessage was called for a role, even if the model was already set to the target model for that role.

This change introduces a check to compare the model before and after the potential switch. The logging message is now only emitted if the model name actually changes.

This prevents verbose and unnecessary log entries during processes like indexing, where the same role (e.g., file_summarizer) is used repeatedly.