### PR TITLE
Fix: Prevent multiple branch creation for same commit

### DIFF
--- a/tests/unit/snapshotManager.branch-creation.test.js
+++ b/tests/unit/snapshotManager.branch-creation.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SnapshotManager from '../../src/core/managers/snapshotManager.js';
+
+// Mock dependencies
+vi.mock('../../src/core/managers/logger.js', () => ({
+    getLogger: vi.fn(),
+}));
+
+vi.mock('../../src/utils/GitUtils.js', () => ({
+    default: vi.fn(),
+}));
+
+describe('SnapshotManager - Branch Creation Logic', () => {
+    let snapshotManager;
+    let mockLogger;
+    let mockGitUtils;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+
+        // Create mock logger
+        mockLogger = {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            user: vi.fn(),
+            debug: vi.fn(),
+        };
+
+        // Create mock GitUtils
+        mockGitUtils = {
+            checkGitAvailability: vi.fn(),
+            getCurrentBranch: vi.fn(),
+            generateBranchName: vi.fn(),
+            createBranch: vi.fn(),
+            switchBranch: vi.fn(),
+            commit: vi.fn(),
+            mergeBranch: vi.fn(),
+            hasUncommittedChanges: vi.fn(),
+        };
+
+        // Setup mocks
+        const loggerModule = await import('../../src/core/managers/logger.js');
+        loggerModule.getLogger.mockReturnValue(mockLogger);
+
+        const GitUtilsModule = await import('../../src/utils/GitUtils.js');
+        GitUtilsModule.default.mockImplementation(() => mockGitUtils);
+
+        // Create SnapshotManager instance
+        snapshotManager = new SnapshotManager();
+    });
+
+    describe('Branch Creation Conditions', () => {
+        beforeEach(async () => {
+            // Setup Git as available and in repo
+            mockGitUtils.checkGitAvailability.mockResolvedValue({
+                available: true,
+                isRepo: true,
+            });
+            mockGitUtils.getCurrentBranch.mockResolvedValue({
+                success: true,
+                branch: 'main',
+            });
+            await snapshotManager.initialize();
+        });
+
+        it('should create branch when not on synth-dev branch and has uncommitted changes', async () => {
+            const instruction = 'Add new feature';
+            mockGitUtils.generateBranchName.mockReturnValue('synth-dev/feature-branch');
+            mockGitUtils.createBranch.mockResolvedValue({ success: true });
+            mockGitUtils.hasUncommittedChanges.mockResolvedValue({
+                success: true,
+                hasUncommittedChanges: true,
+            });
+
+            await snapshotManager.createSnapshot(instruction);
+
+            expect(mockGitUtils.hasUncommittedChanges).toHaveBeenCalled();
+            expect(mockGitUtils.createBranch).toHaveBeenCalledWith('synth-dev/feature-branch');
+            expect(snapshotManager.gitMode).toBe(true);
+            expect(snapshotManager.featureBranch).toBe('synth-dev/feature-branch');
+        });
+
+        it('should NOT create branch when no uncommitted changes', async () => {
+            const instruction = 'Add new feature';
+            mockGitUtils.generateBranchName.mockReturnValue('synth-dev/feature-branch');
+            mockGitUtils.hasUncommittedChanges.mockResolvedValue({
+                success: true,
+                hasUncommittedChanges: false,
+            });
+
+            await snapshotManager.createSnapshot(instruction);
+
+            expect(mockGitUtils.hasUncommittedChanges).toHaveBeenCalled();
+            expect(mockGitUtils.createBranch).not.toHaveBeenCalled();
+            expect(snapshotManager.gitMode).toBe(false);
+            expect(snapshotManager.featureBranch).toBeNull();
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                'Skipping branch creation: no uncommitted changes detected',
+                '📸 Snapshot:'
+            );
+        });
+
+        it('should NOT create branch when already on synth-dev branch', async () => {
+            // Set current branch to a synth-dev branch
+            mockGitUtils.getCurrentBranch.mockResolvedValue({
+                success: true,
+                branch: 'synth-dev/existing-branch',
+            });
+            await snapshotManager._initializeGit(); // Re-initialize with new branch
+
+            const instruction = 'Add new feature';
+            mockGitUtils.generateBranchName.mockReturnValue('synth-dev/feature-branch');
+            mockGitUtils.hasUncommittedChanges.mockResolvedValue({
+                success: true,
+                hasUncommittedChanges: true,
+            });
+
+            await snapshotManager.createSnapshot(instruction);
+
+            // When already on synth-dev branch, we don't check uncommitted changes
+            expect(mockGitUtils.hasUncommittedChanges).not.toHaveBeenCalled();
+            expect(mockGitUtils.createBranch).not.toHaveBeenCalled();
+            expect(snapshotManager.gitMode).toBe(true); // Should enable Git mode
+            expect(snapshotManager.featureBranch).toBe('synth-dev/existing-branch'); // Use existing branch
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                'Skipping branch creation: already on synth-dev branch: synth-dev/existing-branch',
+                '📸 Snapshot:'
+            );
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                'Using existing synth-dev branch: synth-dev/existing-branch',
+                '📸 Snapshot:'
+            );
+        });
+
+        it('should handle Git status check failure gracefully', async () => {
+            const instruction = 'Add new feature';
+            mockGitUtils.hasUncommittedChanges.mockResolvedValue({
+                success: false,
+                error: 'Git status failed',
+            });
+
+            await snapshotManager.createSnapshot(instruction);
+
+            expect(mockGitUtils.hasUncommittedChanges).toHaveBeenCalled();
+            expect(mockGitUtils.createBranch).not.toHaveBeenCalled();
+            expect(snapshotManager.gitMode).toBe(false);
+            expect(snapshotManager.featureBranch).toBeNull();
+            expect(mockLogger.warn).toHaveBeenCalledWith(
+                'Failed to check Git status: Git status failed',
+                '📸 Snapshot:'
+            );
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                'Skipping branch creation: unable to check Git status: Git status failed',
+                '📸 Snapshot:'
+            );
+        });
+    });
+});

--- a/tests/unit/snapshotManager.git.test.js
+++ b/tests/unit/snapshotManager.git.test.js
@@ -53,6 +53,7 @@ describe('SnapshotManager - Git Mode', () => {
             resetToCommit: vi.fn(),
             getCommitDetails: vi.fn(),
             commitExists: vi.fn(),
+            hasUncommittedChanges: vi.fn(),
         };
 
         // Setup mocks
@@ -82,6 +83,11 @@ describe('SnapshotManager - Git Mode', () => {
             // Setup Git mode
             mockGitUtils.generateBranchName.mockReturnValue('synth-dev/test-branch');
             mockGitUtils.createBranch.mockResolvedValue({ success: true });
+            // Mock that there are uncommitted changes to trigger branch creation
+            mockGitUtils.hasUncommittedChanges.mockResolvedValue({
+                success: true,
+                hasUncommittedChanges: true,
+            });
 
             await snapshotManager.createSnapshot('Test instruction');
         });
@@ -233,6 +239,11 @@ describe('SnapshotManager - Git Mode', () => {
             // Setup Git mode
             mockGitUtils.generateBranchName.mockReturnValue('synth-dev/test-branch');
             mockGitUtils.createBranch.mockResolvedValue({ success: true });
+            // Mock that there are uncommitted changes to trigger branch creation
+            mockGitUtils.hasUncommittedChanges.mockResolvedValue({
+                success: true,
+                hasUncommittedChanges: true,
+            });
 
             await snapshotManager.createSnapshot('Test instruction');
         });

--- a/tests/unit/snapshotManager.test.js
+++ b/tests/unit/snapshotManager.test.js
@@ -36,6 +36,7 @@ describe('SnapshotManager', () => {
             warn: vi.fn(),
             error: vi.fn(),
             user: vi.fn(),
+            debug: vi.fn(),
         };
 
         // Create mock GitUtils
@@ -47,6 +48,7 @@ describe('SnapshotManager', () => {
             switchBranch: vi.fn(),
             commit: vi.fn(),
             mergeBranch: vi.fn(),
+            hasUncommittedChanges: vi.fn(),
         };
 
         // Setup mocks
@@ -152,6 +154,11 @@ describe('SnapshotManager', () => {
             const instruction = 'Add new feature';
             mockGitUtils.generateBranchName.mockReturnValue('synth-dev/feature-branch');
             mockGitUtils.createBranch.mockResolvedValue({ success: true });
+            // Mock that there are uncommitted changes to trigger branch creation
+            mockGitUtils.hasUncommittedChanges.mockResolvedValue({
+                success: true,
+                hasUncommittedChanges: true,
+            });
 
             await snapshotManager.createSnapshot(instruction);
 
@@ -203,6 +210,11 @@ describe('SnapshotManager', () => {
             mockGitUtils.createBranch.mockResolvedValue({
                 success: false,
                 error: 'Branch creation failed',
+            });
+            // Mock that there are uncommitted changes to trigger branch creation attempt
+            mockGitUtils.hasUncommittedChanges.mockResolvedValue({
+                success: true,
+                hasUncommittedChanges: true,
             });
 
             await snapshotManager.createSnapshot(instruction);


### PR DESCRIPTION
## Problem

The system was creating new branches too frequently, often creating multiple branches for the same commit. This happened because branch creation was triggered whenever:
- It was the first snapshot (snapshots array was empty)
- Git was available and in a repository

This occurred regardless of whether we were already on a `synth-dev` branch or if there were any uncommitted changes to warrant a new branch.

## Solution

Implemented proper branch creation logic that only creates a new branch when:
1. **Currently NOT on a `synth-dev` branch**, AND
2. **There are uncommitted changes waiting to be added and committed**

## Changes Made

### Core Logic Changes
- **Modified `_handleFirstSnapshotGit()`** in `snapshotManager.js` to use new branch creation logic
- **Added `_shouldCreateNewBranch()`** method that implements the proper conditions for branch creation
- **Enhanced error handling** for Git status check failures
- **Added debug logging** to explain why branches are or aren't created

### Key Behaviors
- ✅ **Creates branch** when not on synth-dev branch and has uncommitted changes
- ✅ **Skips branch creation** when no uncommitted changes detected
- ✅ **Skips branch creation** when already on synth-dev branch (but enables Git mode to use existing branch)
- ✅ **Graceful error handling** if Git status check fails

### Testing
- **Updated existing tests** to work with new logic (added missing mock methods)
- **Added comprehensive test suite** in `snapshotManager.branch-creation.test.js` covering all scenarios
- **All tests passing** - 1062 tests across 59 test files

## Files Changed
- `src/core/managers/snapshotManager.js` - Core logic implementation
- `tests/unit/snapshotManager.test.js` - Updated mocks and test expectations
- `tests/unit/snapshotManager.git.test.js` - Updated mocks for Git mode tests
- `tests/unit/snapshotManager.branch-creation.test.js` - New comprehensive test suite

## Impact
- **Reduces unnecessary branch creation** - better Git hygiene
- **Respects existing synth-dev branches** - won't create duplicates
- **Provides clear feedback** - debug logging explains decisions
- **Maintains backward compatibility** - all existing functionality preserved

Fixes the issue where users would frequently see multiple branches created for the same commit, implementing the expected behavior described in the issue.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author