### PR TITLE
Fix agent_description loading issue when roles are overwritten

### DIFF
--- a/src/config/validation/configurationLoader.js
+++ b/src/config/validation/configurationLoader.js
@@ -288,14 +288,42 @@ class ConfigurationLoader {
                         this.logger.warn(
                             `Role '${roleName}' from ${filePath} overwrites existing role definition`
                         );
-                    }
 
-                    // Add group metadata to role config
-                    mergedRoles[roleName] = {
-                        ...roleConfig,
-                        _group: group,
-                        _source: jsonFile,
-                    };
+                        // Preserve important fields from the original role if they're missing in the new one
+                        const existingRole = mergedRoles[roleName];
+                        const preservedFields = {};
+
+                        // Preserve agent_description if it exists in the original but not in the new role
+                        if (existingRole.agent_description && !roleConfig.agent_description) {
+                            preservedFields.agent_description = existingRole.agent_description;
+                        }
+
+                        // Preserve enabled_agents if it exists in the original but not in the new role
+                        if (existingRole.enabled_agents && !roleConfig.enabled_agents) {
+                            preservedFields.enabled_agents = existingRole.enabled_agents;
+                        }
+
+                        // Preserve can_create_tasks_for if it exists in the original but not in the new role
+                        if (existingRole.can_create_tasks_for && !roleConfig.can_create_tasks_for) {
+                            preservedFields.can_create_tasks_for =
+                                existingRole.can_create_tasks_for;
+                        }
+
+                        // Add group metadata to role config with preserved fields
+                        mergedRoles[roleName] = {
+                            ...preservedFields,
+                            ...roleConfig,
+                            _group: group,
+                            _source: jsonFile,
+                        };
+                    } else {
+                        // Add group metadata to role config
+                        mergedRoles[roleName] = {
+                            ...roleConfig,
+                            _group: group,
+                            _source: jsonFile,
+                        };
+                    }
 
                     // Track role in group
                     if (!roleGroups[group]) {

--- a/tests/unit/core/systemMessages.realConfig.test.js
+++ b/tests/unit/core/systemMessages.realConfig.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import SystemMessages from '../../../src/core/ai/systemMessages.js';
+
+describe('SystemMessages - Real Configuration Loading', () => {
+    beforeEach(() => {
+        // Clear any cached instances
+        vi.clearAllMocks();
+    });
+
+    describe('Agent Description Loading from Real Config', () => {
+        it('should load agent_description from team-roles.agentic.json correctly', () => {
+            const systemMessage = SystemMessages.getSystemMessage('pm');
+
+            // The system message should contain the architect's description from the config file
+            expect(systemMessage).toContain(
+                'architect - responsible for designing system architectures'
+            );
+
+            // Should not contain "No description available" for architect
+            expect(systemMessage).not.toContain('architect - No description available');
+        });
+
+        it('should load all agent descriptions from agentic roles correctly', () => {
+            const systemMessage = SystemMessages.getSystemMessage('architect');
+
+            // The system message should contain the developer's description
+            expect(systemMessage).toContain('developer - responsible for implementing features');
+
+            // Should not contain "No description available" for developer
+            expect(systemMessage).not.toContain('developer - No description available');
+        });
+
+        it('should handle pm role with architect coordination', () => {
+            const systemMessage = SystemMessages.getSystemMessage('pm');
+
+            console.log('PM System Message:', systemMessage);
+
+            // Should contain coordination info
+            expect(systemMessage).toContain(
+                'Your role is pm and you need to coordinate with other roles'
+            );
+            expect(systemMessage).toContain('architect');
+
+            // Should contain proper architect description
+            expect(systemMessage).toContain(
+                'architect - responsible for designing system architectures'
+            );
+        });
+
+        it('should handle architect role with developer coordination', () => {
+            const systemMessage = SystemMessages.getSystemMessage('architect');
+
+            console.log('Architect System Message:', systemMessage);
+
+            // Should contain coordination info
+            expect(systemMessage).toContain(
+                'Your role is architect and you need to coordinate with other roles'
+            );
+            expect(systemMessage).toContain('developer');
+
+            // Should contain proper developer description
+            expect(systemMessage).toContain('developer - responsible for implementing features');
+        });
+
+        it('should handle developer role with test-runner and git-manager coordination', () => {
+            const systemMessage = SystemMessages.getSystemMessage('developer');
+
+            console.log('Developer System Message:', systemMessage);
+
+            // Should contain coordination info
+            expect(systemMessage).toContain(
+                'Your role is developer and you need to coordinate with other roles'
+            );
+            expect(systemMessage).toContain('test-runner');
+            expect(systemMessage).toContain('git-manager');
+
+            // Should contain proper descriptions
+            expect(systemMessage).toContain('test-runner - responsible for running existing tests');
+            expect(systemMessage).toContain(
+                'git-manager - responsible for handling git operations'
+            );
+        });
+    });
+
+    describe('Debug Role Loading', () => {
+        it('should show what roles are actually loaded', () => {
+            const instance = new SystemMessages();
+            const roles = instance.roles;
+
+            console.log('Loaded roles:', Object.keys(roles));
+            console.log('PM role config:', roles.pm);
+            console.log('Architect role config:', roles.architect);
+            console.log('Developer role config:', roles.developer);
+        });
+    });
+});


### PR DESCRIPTION
## Problem

The `agent_description` field was being lost when role configurations were overwritten by later configuration files. Specifically, the `architect` role from `core.json` was overwriting the `team-roles.agentic.json` definition without preserving the `agent_description` field, causing system messages to show "No description available" instead of the proper agent descriptions.

## Root Cause

In `configurationLoader.js`, when a role was overwritten, the code was doing a complete replacement:

```javascript
mergedRoles[roleName] = {
    ...roleConfig,
    _group: group,
    _source: jsonFile,
};
```

This completely replaced the existing role instead of merging important fields.

## Solution

Implemented intelligent field preservation when roles are overwritten:

- Preserve `agent_description` from the original role if the new role doesn't have one
- Preserve `enabled_agents` from the original role if the new role doesn't have one  
- Preserve `can_create_tasks_for` from the original role if the new role doesn't have one

This ensures that important agentic configuration fields are not lost during role overrides.

## Testing

- Added comprehensive tests in `systemMessages.realConfig.test.js` that verify agent descriptions are properly loaded from real configuration files
- All existing tests continue to pass
- Verified that system messages now correctly show agent descriptions instead of "No description available"

## Before/After

**Before:** `architect - No description available`

**After:** `architect - responsible for designing system architectures, creating technical specifications, and providing granular tasks for developers, should recive high level tasks to process`

Fixes the issue where agent coordination information was incomplete in system messages.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author